### PR TITLE
Overhaul of stat-collecting scripts (and switch to PR-based import latency)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,19 @@ branches:
     - master
 language: python
 python:
-  - "2.7"
+  - "3.6"
+install:
+  # dependencies of wpt-{import,export}-stats.py
+  - pip install numpy dateutil requests
+  # depot tools (for git crrev-parse)
+  - git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  - export PATH=$PATH:$PWD/depot_tools
 script:
   - mkdir out
   # upstream wpt checkout (easy!)
   - git clone https://github.com/w3c/web-platform-tests.git
   # upstream wpt stats
   - ./wpt-stats.sh web-platform-tests > out/wpt-commits.csv
-  # depot tools (for git crrev-parse)
-  - git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-  - export PATH=$PATH:$PWD/depot_tools
   # chromium checkout
   # use mirror, as github suppports --shallow-since and gives smaller packs
   - git clone --shallow-since=2017-01-01 https://github.com/scheib/chromium.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ branches:
     - master
 language: python
 python:
+  - "2.7"
   - "3.6"
 install:
   # dependencies of wpt-{import,export}-stats.py
-  - pip install numpy python-dateutil requests
+  - pip3 install numpy python-dateutil requests
   # depot tools (for git crrev-parse)
   - git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
   - export PATH=$PATH:$PWD/depot_tools
@@ -20,14 +21,14 @@ script:
   # use mirror, as github suppports --shallow-since and gives smaller packs
   - git clone --shallow-since=2017-01-01 https://github.com/scheib/chromium.git
   # chromium import stats
-  - python wpt-import-stats.py chromium web-platform-tests
+  - python3 wpt-import-stats.py chromium web-platform-tests
   - mv import-latencies.csv out/chromium-import-latency.csv
   # chromium export stats
-  - python wpt-export-stats.py chromium
+  - python3 wpt-export-stats.py chromium
   - mv export-latencies.csv out/chromium-export-latency.csv
   # chromium usage stats
   - mv wpt-usage-stats chromium/third_party/WebKit/Tools/Scripts/
-  - chromium/third_party/WebKit/Tools/Scripts/wpt-usage-stats 2017-11-01 2017-12-01 > out/chromium-usage-stats.txt
+  - python2 chromium/third_party/WebKit/Tools/Scripts/wpt-usage-stats 2017-11-01 2017-12-01 > out/chromium-usage-stats.txt
   # bonus: chromium OWNERS check
   - ./chromium-wpt-owners.sh chromium/third_party/WebKit/LayoutTests/external/wpt > out/chromium-wpt-owners.txt
   - mv static/* out/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
 install:
   # dependencies of wpt-{import,export}-stats.py
-  - pip install numpy dateutil requests
+  - pip install numpy python-dateutil requests
   # depot tools (for git crrev-parse)
   - git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
   - export PATH=$PATH:$PWD/depot_tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ branches:
 language: python
 python:
   - "2.7"
-  - "3.6"
 install:
   # dependencies of wpt-{import,export}-stats.py
-  - pip3 install numpy python-dateutil requests
+  - pip install numpy python-dateutil requests
   # depot tools (for git crrev-parse)
   - git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
   - export PATH=$PATH:$PWD/depot_tools
@@ -21,14 +20,14 @@ script:
   # use mirror, as github suppports --shallow-since and gives smaller packs
   - git clone --shallow-since=2017-01-01 https://github.com/scheib/chromium.git
   # chromium import stats
-  - python3 wpt-import-stats.py chromium web-platform-tests
+  - python wpt-import-stats.py chromium web-platform-tests
   - mv import-latencies.csv out/chromium-import-latency.csv
   # chromium export stats
-  - python3 wpt-export-stats.py chromium
+  - python wpt-export-stats.py chromium
   - mv export-latencies.csv out/chromium-export-latency.csv
   # chromium usage stats
   - mv wpt-usage-stats chromium/third_party/WebKit/Tools/Scripts/
-  - python2 chromium/third_party/WebKit/Tools/Scripts/wpt-usage-stats 2017-11-01 2017-12-01 > out/chromium-usage-stats.txt
+  - python chromium/third_party/WebKit/Tools/Scripts/wpt-usage-stats 2017-11-01 2017-12-01 > out/chromium-usage-stats.txt
   # bonus: chromium OWNERS check
   - ./chromium-wpt-owners.sh chromium/third_party/WebKit/LayoutTests/external/wpt > out/chromium-wpt-owners.txt
   - mv static/* out/

--- a/wpt-export-stats.py
+++ b/wpt-export-stats.py
@@ -37,13 +37,13 @@ def fetch_all_prs():
 
     print('Fetching all PRs')
 
-    url = ('/search/issues?q='
+    base_url = ('/search/issues?q='
            'repo:w3c/web-platform-tests%20'
            'type:pr%20'
            'is:merged%20'
            'label:chromium-export')
 
-    init_data = github_request(url)
+    init_data = github_request(base_url)
     total = init_data['total_count']
     print(total, 'total PRs')
 
@@ -55,7 +55,7 @@ def fetch_all_prs():
     cutoff = dateutil.parser.parse(CUTOFF)
     for page in range(1, total_pages + 1):
         print('Fetching page', page)
-        url += '&page={}&per_page={}'.format(page, page_size)
+        url = base_url + '&page={}&per_page={}'.format(page, page_size)
         data = github_request(url)
         if 'items' not in data:
             print('No items in page {}. Probably reached rate limit. Stopping.'.format(page))
@@ -73,17 +73,6 @@ def fetch_all_prs():
     with open(PRS_FILE, 'w') as f:
         json.dump(prs, f)
     return prs
-
-
-def filter_prs(prs, cutoff):
-    cutoff_time = dateutil.parser.parse(cutoff)
-    filtered_prs = []
-    for pr in prs:
-        pr_closed_at = dateutil.parser.parse(pr['closed_at'])
-        if pr_closed_at >= cutoff_time:
-            filtered_prs.append(pr)
-    print(len(filtered_prs), 'merged since', cutoff)
-    return filtered_prs
 
 
 def get_sha_from_change_id(change_id):
@@ -220,8 +209,7 @@ def analyze_mins(min_differences):
 
 def main():
     all_prs = fetch_all_prs()
-    filtered_prs = filter_prs(all_prs, CUTOFF)
-    min_differences = calculate_pr_delays(filtered_prs)
+    min_differences = calculate_pr_delays(all_prs)
     analyze_mins(min_differences)
 
 

--- a/wpt-export-stats.py
+++ b/wpt-export-stats.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # History: https://gist.github.com/jeffcarp/f1fb015e38f50e82d30b8c69b67faa74
 #          https://gist.github.com/Hexcles/ec811c9dd45a0f21bb3fc3243bfa857a
-# Requirements: numpy & requests ( sudo apt install python-{numpy,requests} )
+# Requirements: python-datautil, numpy & requests
 
 from __future__ import print_function
 import csv
@@ -110,8 +110,7 @@ def calculate_pr_delays(prs):
 
     for index, pr in enumerate(prs):
         pr_number = pr['number']
-        print('[{}/{}] PR: https://github.com/w3c/web-platform-tests/pull/{}'
-              .format(index+1, total_prs, pr_number))
+        print('[{}/{}] PR: {}'.format(index+1, total_prs, pr['html_url']))
         pr_closed_at = dateutil.parser.parse(pr['closed_at'])
 
         match = re.search(r'^Change-Id\: (.+)$', pr['body'], re.MULTILINE)

--- a/wpt-export-stats.py
+++ b/wpt-export-stats.py
@@ -140,10 +140,10 @@ def calculate_pr_delays(prs):
 
         output = chromium_git(['show', '-s', '--format=%cI', sha])
         commit_time = dateutil.parser.parse(output)
+        mins_difference = (pr_closed_at - commit_time).total_seconds() / 60
 
         print('Committed at', commit_time)
         print('PR closed at', pr_closed_at)
-        mins_difference = (pr_closed_at - commit_time).total_seconds() / 60
         print('Delay (mins):', mins_difference)
         if mins_difference < 0:
             print('Negative delay. SKIPPING!')

--- a/wpt-export-stats.py
+++ b/wpt-export-stats.py
@@ -1,34 +1,22 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # History: https://gist.github.com/jeffcarp/f1fb015e38f50e82d30b8c69b67faa74
 #          https://gist.github.com/Hexcles/ec811c9dd45a0f21bb3fc3243bfa857a
 # Requirements: numpy & requests ( sudo apt install python-{numpy,requests} )
 
 from __future__ import print_function
-from datetime import datetime
 import csv
 import collections
+import dateutil.parser
 import json
 import numpy
-import os
-import requests
 import re
-import subprocess
-import sys
+
+# FIXME: I know this is bad...
+from wpt_common import *
 
 
-# Only PRs after this time (UTC) will be processed.
-CUTOFF = '2017-07-01T00:00:00Z'
-QUARTER_START = '2017-10-01T00:00:00Z'
-try:
-    CHROMIUM_DIR = sys.argv[1]
-except IndexError:
-    CHROMIUM_DIR = os.path.expanduser('~/chromium/src')
-GH_USER = os.environ.get('GH_USER')
-GH_TOKEN = os.environ.get('GH_TOKEN')
 # Target SLA (in minutes).
 SLA = 60
-# GitHub cache. Remove to fetch PRs again.
-PRS_FILE = 'prs.json'
 # Result files.
 MINS_FILE = 'export-mins.json'
 CSV_FILE = 'export-latencies.csv'
@@ -36,64 +24,11 @@ CSV_FILE = 'export-latencies.csv'
 _GITHUB_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
-def fetch_all_prs():
-    try:
-        with open(PRS_FILE) as f:
-            all_prs = json.load(f)
-            print('Read', len(all_prs), 'PRs from', PRS_FILE)
-            return all_prs
-    except Exception:
-        pass
-
-    print('Fetching all PRs')
-    base_url = 'https://api.github.com/search/issues?q=repo:w3c/web-platform-tests%20type:pr%20label:chromium-export%20is:merged'
-    github_oauth = (GH_USER, GH_TOKEN) if (GH_USER and GH_TOKEN) else None
-    if github_oauth is None:
-        print('Warning: Provide GH_USER and GH_TOKEN to get full results (otherwise limited to <500 PRs)')
-
-    res = requests.get(base_url, auth=github_oauth)
-    data = res.json()
-
-    total = data['total_count']
-
-    print(total, 'total PRs')
-
-    page_size = 50
-    total_pages = int(total / page_size) + 1
-
-    prs = []
-
-    for page in range(1, total_pages + 1):
-        print('Fetching page', page)
-        res = requests.get('{}&page={}&per_page={}'.format(base_url, page, page_size),
-                           auth=github_oauth)
-        data = res.json()
-        if 'items' not in data:
-            print('No items in page', page, 'stopping')
-            break
-        prs.extend(data['items'])
-
-    print('Fetched', len(prs), 'merged PRs with chromium-export label')
-
-    print('Writing file', PRS_FILE)
-    with open(PRS_FILE, 'w') as f:
-        json.dump(prs, f)
-    return prs
-
-
-def _parse_github_time(timestr):
-    return datetime.strptime(timestr, _GITHUB_DATE_FORMAT)
-
-
-def _parse_git_time(timestr):
-    return datetime.strptime(timestr, '%Y-%m-%dT%H:%M:%S+00:00')
-
-
 def filter_prs(prs, cutoff):
-    cutoff_time = _parse_github_time(cutoff)
+    cutoff_time = dateutil.parser.parse(cutoff)
     filtered_prs = []
     for pr in prs:
-        pr_closed_at = _parse_github_time(pr['closed_at'])
+        pr_closed_at = dateutil.parser.parse(pr['closed_at'])
         if pr_closed_at >= cutoff_time:
             filtered_prs.append(pr)
     print(len(filtered_prs), 'merged since', cutoff)
@@ -102,12 +37,8 @@ def filter_prs(prs, cutoff):
 
 def get_sha_from_change_id(change_id):
     grep = '^Change-Id: ' + change_id + '$'
-    cmd = ['git', 'log', 'origin/master', '--format=%H', '-1', '--grep=%s' % grep]
-    print(' '.join(cmd))
-    p = subprocess.Popen(cmd, cwd=CHROMIUM_DIR, stdout=subprocess.PIPE)
-    p.wait()
-
-    sha = p.stdout.readline().strip()
+    args = ['log', 'origin/master', '--format=%H', '-1', '--grep=%s' % grep]
+    sha = chromium_git(args)
     if len(sha) == 40:
         return sha
     else:
@@ -115,12 +46,8 @@ def get_sha_from_change_id(change_id):
 
 
 def get_sha_from_commit_position(commit_position):
-    cmd = ['git', 'crrev-parse', commit_position]
-    print(' '.join(cmd))
-    p = subprocess.Popen(cmd, cwd=CHROMIUM_DIR, stdout=subprocess.PIPE)
-    p.wait()
-
-    sha = p.stdout.readline().strip()
+    args = ['crrev-parse', commit_position]
+    sha = chromium_git(args)
     if len(sha) == 40:
         return sha
     else:
@@ -143,23 +70,23 @@ def calculate_pr_delays(prs):
     for index, pr in enumerate(prs):
         pr_number = pr['number']
         print('[%d/%d] PR: https://github.com/w3c/web-platform-tests/pull/%s' % (index+1, total_prs, pr_number))
-        pr_closed_at = _parse_github_time(pr['closed_at'])
+        pr_closed_at = dateutil.parser.parse(pr['closed_at'])
 
-        match = re.search('^Change-Id\: (.+)$', pr['body'], re.MULTILINE)
+        match = re.search(r'^Change-Id\: (.+)$', pr['body'], re.MULTILINE)
 
         try:
             change_id = match.groups()[0].strip()
             print('Found Change-Id', change_id)
             sha = get_sha_from_change_id(change_id)
-        except AttributeError as e:
+        except AttributeError:
             print('Could not get Change-Id from PR, trying Cr-Commit-Position')
-            match = re.search('^Cr-Commit-Position\: (.+)$', pr['body'], re.MULTILINE)
+            match = re.search(r'^Cr-Commit-Position\: (.+)$', pr['body'], re.MULTILINE)
 
             try:
                 commit_position = match.groups()[0].strip()
                 print('Found Cr-Commit-Position', commit_position)
                 sha = get_sha_from_commit_position(commit_position)
-            except AttributeError as e:
+            except AttributeError:
                 sha = None
 
         if sha is None:
@@ -169,10 +96,8 @@ def calculate_pr_delays(prs):
 
         print('Found SHA', sha)
 
-        p = subprocess.Popen(['git', 'show', '-s', '--format=%cI', sha],
-                             cwd=CHROMIUM_DIR, stdout=subprocess.PIPE)
-        p.wait()
-        commit_time = _parse_git_time(p.stdout.readline().strip())
+        output = chromium_git(['show', '-s', '--format=%cI', sha])
+        commit_time = dateutil.parser.parse(output)
 
         print('Committed at', commit_time)
         print('PR closed at', pr_closed_at)
@@ -203,10 +128,10 @@ def calculate_pr_delays(prs):
 def analyze_mins(min_differences):
     min_differences_by_month = collections.defaultdict(list)
     this_quarter = []
-    quarter_cutoff = _parse_github_time(QUARTER_START)
-    for datapoint in min_differences.itervalues():
+    quarter_cutoff = dateutil.parser.parse(QUARTER_START)
+    for datapoint in min_differences.values():
         min_differences_by_month[datapoint['month']].append(datapoint['latency'])
-        if _parse_github_time(datapoint['time']) >= quarter_cutoff:
+        if dateutil.parser.parse(datapoint['time']) >= quarter_cutoff:
             this_quarter.append(datapoint['latency'])
 
     print('NOTE: Results eariler than cutoff time (%s) are not accurate.' % CUTOFF)

--- a/wpt-export-stats.py
+++ b/wpt-export-stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 # History: https://gist.github.com/jeffcarp/f1fb015e38f50e82d30b8c69b67faa74
 #          https://gist.github.com/Hexcles/ec811c9dd45a0f21bb3fc3243bfa857a
 # Requirements: python-datautil, numpy & requests

--- a/wpt-import-stats.py
+++ b/wpt-import-stats.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # History: https://gist.github.com/Hexcles/ec48b4f674ad66c6d34cf279c262a4de
-# Requirements: numpy & dateutil ( sudo apt install python-{numpy,dateutil} )
+# Requirements: python-dateutil, numpy & requests
 
 from __future__ import print_function
 from collections import defaultdict, namedtuple
@@ -136,8 +136,9 @@ def get_latencies(imports, all_prs):
         pass
 
     latencies = {}
+    total_prs = len(all_prs)
     for i, pr in enumerate(all_prs):
-        print("{}/{} PRs".format(i + 1, len(all_prs)))
+        print("[{}/{}] PR: {}".format(i + 1, len(total_prs), pr['html_url']))
         merge_commit = pr['merge_commit_sha']
         merged_at = pr['merged_at']
         assert merge_commit

--- a/wpt-import-stats.py
+++ b/wpt-import-stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 # History: https://gist.github.com/Hexcles/ec48b4f674ad66c6d34cf279c262a4de
 # Requirements: python-dateutil, numpy & requests
 

--- a/wpt-usage-stats
+++ b/wpt-usage-stats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright 2017 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/wpt_common.py
+++ b/wpt_common.py
@@ -3,8 +3,6 @@ Python 3 please.
 """
 
 from __future__ import print_function
-import dateutil.parser
-import json
 import os
 import requests
 import sys

--- a/wpt_common.py
+++ b/wpt_common.py
@@ -1,0 +1,94 @@
+"""A bunch of common functions shared by wpt-{import,export}-stats.
+Python 3 please.
+"""
+
+from __future__ import print_function
+import json
+import os
+import requests
+import sys
+import subprocess
+
+# Only PRs after this time (UTC) will be processed. Our 2-way sync really
+# started to stablize around this time. Earlier results are inaccurate.
+CUTOFF = '2017-07-01T00:00:00Z'
+# Change this when it is a new quarter.
+QUARTER_START = '2017-10-01T00:00:00Z'
+
+# Read tokens from env vars.
+GH_USER = os.environ.get('GH_USER')
+GH_TOKEN = os.environ.get('GH_TOKEN')
+
+# GitHub cache. Delete the file to fetch PRs again.
+PRS_FILE = 'prs.json'
+
+try:
+    CHROMIUM_DIR = sys.argv[1]
+except IndexError:
+    CHROMIUM_DIR = os.path.expanduser('~/chromium/src')
+
+try:
+    WPT_DIR = sys.argv[2]
+except IndexError:
+    WPT_DIR = os.path.expanduser('~/github/web-platform-tests')
+
+
+def git(args, cwd):
+    command = ['git'] + args
+    output = subprocess.check_output(command, cwd=cwd)
+    # Alright this only works in UTF-8 locales...
+    return output.decode('utf-8').rstrip()
+
+
+def chromium_git(args):
+    return git(args, cwd=CHROMIUM_DIR)
+
+
+def wpt_git(args):
+    return git(args, cwd=WPT_DIR)
+
+
+def fetch_all_prs():
+    try:
+        with open(PRS_FILE) as f:
+            all_prs = json.load(f)
+            print('Read', len(all_prs), 'PRs from', PRS_FILE)
+            return all_prs
+    except Exception:
+        pass
+
+    print('Fetching all PRs')
+    base_url = 'https://api.github.com/search/issues?q=repo:w3c/web-platform-tests%20type:pr%20label:chromium-export%20is:merged'
+    github_oauth = (GH_USER, GH_TOKEN) if (GH_USER and GH_TOKEN) else None
+    if github_oauth is None:
+        print('Warning: Provide GH_USER and GH_TOKEN to get full results (otherwise limited to <500 PRs)')
+
+    res = requests.get(base_url, auth=github_oauth)
+    data = res.json()
+
+    total = data['total_count']
+
+    print(total, 'total PRs')
+
+    page_size = 50
+    total_pages = int(total / page_size) + 1
+
+    prs = []
+
+    for page in range(1, total_pages + 1):
+        print('Fetching page', page)
+        res = requests.get(
+            '{}&page={}&per_page={}'.format(base_url, page, page_size),
+            auth=github_oauth)
+        data = res.json()
+        if 'items' not in data:
+            print('No items in page', page, 'stopping')
+            break
+        prs.extend(data['items'])
+
+    print('Fetched', len(prs), 'merged PRs with chromium-export label')
+
+    print('Writing file', PRS_FILE)
+    with open(PRS_FILE, 'w') as f:
+        json.dump(prs, f)
+    return prs

--- a/wpt_common.py
+++ b/wpt_common.py
@@ -1,5 +1,5 @@
 """A bunch of common functions shared by wpt-{import,export}-stats.
-Python 3 please.
+Python 6 (2 and 3 compatible) please.
 """
 
 from __future__ import print_function


### PR DESCRIPTION
This big change mainly includes the following aspects:

* Some common routines are extracted out.
* wpt-export-stats does not have major behaviour changes, just some bug fixes and cleanups.
* wpt-import-stats is completely rewritten to calculate latency based on PRs instead of WPT commits.
* Logging and error handling are improved a bit overall.