### PR TITLE
Bump hardcoded dates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ mv *.csv "$OUTDIR/"
 
 echo "chromium usage stats..."
 cp wpt_usage_stats.py "$CHROMIUM_DIR/third_party/blink/tools/"
-"$CHROMIUM_DIR/third_party/blink/tools/wpt_usage_stats.py" 2019-10-01 2019-11-01 > "$OUTDIR/chromium-usage-stats.txt"
+"$CHROMIUM_DIR/third_party/blink/tools/wpt_usage_stats.py" 2019-12-01 2020-01-01 > "$OUTDIR/chromium-usage-stats.txt"
 rm "$CHROMIUM_DIR/third_party/blink/tools/wpt_usage_stats.py"
 echo
 

--- a/wpt_common.py
+++ b/wpt_common.py
@@ -19,7 +19,7 @@ from csv_database import PRDB
 # started to stablize around this time. Earlier results are inaccurate.
 CUTOFF = '2017-07-01T00:00:00Z'
 # Change this when it is a new quarter.
-QUARTER_START = '2019-10-01T00:00:00Z'
+QUARTER_START = '2020-01-01T00:00:00Z'
 
 # GitHub cache. Delete the file to fetch PRs again.
 PRS_FILE = 'wpt-prs.csv'


### PR DESCRIPTION
Chromium WPT usage was updated for 2019-10, 2019-11, and 2019-12 along
the way, and the results uploaded to
https://docs.google.com/spreadsheets/d/1bkrluvwifFajCN2oyOyNCl7wgTKR1M6J7PGTFlv-KX4/edit#gid=0